### PR TITLE
mount_uploader automatically creates Uploader property

### DIFF
--- a/lib/carrierwave/datamapper.rb
+++ b/lib/carrierwave/datamapper.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'dm-core'
+require 'carrierwave/datamapper/property/uploader'
 
 module CarrierWave
   module DataMapper
@@ -11,14 +12,23 @@ module CarrierWave
     # See +CarrierWave::Mount#mount_uploader+ for documentation
     #
     def mount_uploader(column, uploader, options={}, &block)
+      if properties.named?(column)
+        warn "Defining property for an uploader is deprecated at #{caller[2]}"
+        properties.delete(properties[column])
+      end
+
+      property column, Property::Uploader
+
       super
 
-      alias_method :read_uploader, :attribute_get
+      alias_method :read_uploader,  :attribute_get
       alias_method :write_uploader, :attribute_set
-      after :save, "store_#{column}!".to_sym
+
       pre_hook = ::DataMapper.const_defined?(:Validate) ? :valid? : :save
+
       before pre_hook, "write_#{column}_identifier".to_sym
-      after :destroy, "remove_#{column}!".to_sym
+      after  :save,    "store_#{column}!".to_sym
+      after  :destroy, "remove_#{column}!".to_sym
 
       # FIXME: Hack to work around Datamapper not triggering callbacks
       # for objects that are not dirty. By explicitly calling
@@ -39,4 +49,4 @@ module CarrierWave
   end # DataMapper
 end # CarrierWave
 
-DataMapper::Model.send(:include, CarrierWave::DataMapper)
+DataMapper::Model.append_extensions(CarrierWave::DataMapper)

--- a/lib/carrierwave/datamapper/property/uploader.rb
+++ b/lib/carrierwave/datamapper/property/uploader.rb
@@ -1,0 +1,19 @@
+module CarrierWave
+  module DataMapper
+    module Property
+      class Uploader < ::DataMapper::Property::String
+        def custom?
+          true
+        end
+
+        def initialize(model, name, options = {})
+          if ::DataMapper.const_defined?(:Validate)
+            options[:auto_validation] = false
+          end
+
+          super
+        end
+      end
+    end # Property
+  end # DataMapper
+end # CarrierWave

--- a/spec/datamapper_spec.rb
+++ b/spec/datamapper_spec.rb
@@ -20,13 +20,6 @@ describe CarrierWave::DataMapper do
       storage_names[:default] = 'events'
 
       property :id, DataMapper::Property::Serial
-
-      # auto validation off currently for inferred type
-      # validation. issue is that validations are done on
-      # the value returned by model#property_name which is overloaded
-      # by carrierwave. pull request in @dm-more to remedy this.
-      property :image, String, :auto_validation => false
-
       mount_uploader :image, uploader
     end
 


### PR DESCRIPTION
Custom CarrierWave::DataMapper::Property::Uploader property has
auto validations turned off. When you call mount_uploader(:foo) a
property with the same name will be created for you.

Adding this property class is a first step towards proper validation of
uploader objects. It also makes our users happier as they no longer
need to remember to define a property and turn off auto-validation.
