### PR TITLE
Require 'carrierwave' in carrierwave-datamapper startup.

### DIFF
--- a/lib/carrierwave/datamapper.rb
+++ b/lib/carrierwave/datamapper.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'carrierwave'
 require 'dm-core'
 require 'carrierwave/datamapper/property/uploader'
 


### PR DESCRIPTION
Hi,

In a Rails 3/DataMapper project I'm working on I'm using `gem 'carrierwave-datamapper', :require => 'carrierwave/datamapper'`, but that didn't actually require CarrierWave itself, which I figure it should.

Thanks for CarrierWave!
