### PR TITLE
Respect the :mount_on option.

### DIFF
--- a/lib/carrierwave/datamapper.rb
+++ b/lib/carrierwave/datamapper.rb
@@ -18,7 +18,11 @@ module CarrierWave
         properties.delete(properties[column])
       end
 
-      uploader_property = property(column, Property::Uploader)
+      uploader_property = if options[:mount_on]
+                            properties[options[:mount_on]]
+                          else
+                            property column, Property::Uploader
+                          end
 
       super
 
@@ -37,11 +41,11 @@ module CarrierWave
       class_eval <<-RUBY
         def remove_#{column}=(value)
           _mounter(:#{column}).remove = value
-          attribute_set(:#{column}, '') if _mounter(:#{column}).remove?
+          attribute_set(:#{uploader_property.name}, '') if _mounter(:#{column}).remove?
         end
 
         def #{column}=(value)
-          attribute_set(:#{column}, value)
+          attribute_set(:#{uploader_property.name}, value)
           super(value)
         end
       RUBY

--- a/spec/unit/carrier_wave/data_mapper/mount_uploader_spec.rb
+++ b/spec/unit/carrier_wave/data_mapper/mount_uploader_spec.rb
@@ -46,4 +46,35 @@ describe CarrierWave::DataMapper, '.mount_uploader' do
       it { should respond_to("#{uploader_name}=") }
     end
   end
+
+  context "when using the :mount_on option" do
+    let(:uploader_column) { :image_file_name }
+
+    let(:described_class) do
+      Class.new do
+        include DataMapper::Resource
+
+        property :id, DataMapper::Property::Serial
+
+        property :image_file_name, String
+
+        def self.name; :spec_model; end
+      end
+    end
+
+    let!(:uploader_property) do
+      described_class.mount_uploader uploader_name, uploader,
+                                     :mount_on => :image_file_name
+    end
+
+    it "should not define a new uploader property" do
+      described_class.properties.should_not be_named(:image)
+    end
+
+    describe 'Uploader Property' do
+      subject { uploader_property }
+
+      its(:name)    { should == uploader_column }
+    end
+  end
 end


### PR DESCRIPTION
- When the :mount_on option is specified, use the existing property as
  the uploader identifier column. Otherwise, define a new uploader
  property.
