### PR TITLE
Losen DataMapper dependencies to ~> 1.1 to support 1.2.0 / 1.3.0.

### DIFF
--- a/carrierwave-datamapper.gemspec
+++ b/carrierwave-datamapper.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "dm-core", ["~> 1.1.0"]
+  s.add_dependency "dm-core", ["~> 1.1"]
   s.add_dependency "carrierwave", ["~> 0.5.6"]
   s.add_development_dependency "rspec", ["~> 2.6.0"]
-  s.add_development_dependency "dm-validations", ["~> 1.1.0"]
-  s.add_development_dependency "dm-migrations", ["~> 1.1.0"]
-  s.add_development_dependency "dm-sqlite-adapter", ["~> 1.1.0"]
+  s.add_development_dependency "dm-validations", ["~> 1.1"]
+  s.add_development_dependency "dm-migrations", ["~> 1.1"]
+  s.add_development_dependency "dm-sqlite-adapter", ["~> 1.1"]
 end


### PR DESCRIPTION
This allows me to test carrierwave-datamapper with DM 1.2.0 / edge.
