### PR TITLE
Property string length must be at least 255

### DIFF
--- a/lib/carrierwave/datamapper/property/uploader.rb
+++ b/lib/carrierwave/datamapper/property/uploader.rb
@@ -2,6 +2,9 @@ module CarrierWave
   module DataMapper
     module Property
       class Uploader < ::DataMapper::Property::String
+
+        length 255
+
         def custom?
           true
         end


### PR DESCRIPTION
Datamapper's default is 50, which is insufficient to store path name.
