### PR TITLE
removed depreciation warning

### DIFF
--- a/carrierwave-datamapper.gemspec
+++ b/carrierwave-datamapper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "dm-core", ["~> 1.1"]
-  s.add_dependency "carrierwave", ["~> 0.5.6"]
+  s.add_dependency "carrierwave", ["~> 0.6"]
 
   s.add_development_dependency "rake", ["~> 0.9.2"]
   s.add_development_dependency "rspec", ["~> 2.8"]


### PR DESCRIPTION
In Rails 3.2 I get this warning:

DEPRECATION WARNING: ActiveSupport::Memoizable is deprecated and will be removed in future releases,simply use Ruby memoization pattern instead.

You can see this: https://github.com/jnicklas/carrierwave/issues/433 for more information
