### PR TITLE
Allow 'carrierwave' dependency to be updated to 0.6.x

### DIFF
--- a/carrierwave-datamapper.gemspec
+++ b/carrierwave-datamapper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "dm-core", ["~> 1.1"]
-  s.add_dependency "carrierwave", ["~> 0.5.6"]
+  s.add_dependency "carrierwave", [">= 0.5.6"]
 
   s.add_development_dependency "rake", ["~> 0.9.2"]
   s.add_development_dependency "rspec", ["~> 2.8"]

--- a/carrierwave-datamapper.gemspec
+++ b/carrierwave-datamapper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "dm-core", ["~> 1.1"]
-  s.add_dependency "carrierwave", [">= 0.5.6"]
+  s.add_dependency "carrierwave", ["~> 0.6.0"]
 
   s.add_development_dependency "rake", ["~> 0.9.2"]
   s.add_development_dependency "rspec", ["~> 2.8"]


### PR DESCRIPTION
The current gemspec has carrierwave ~> 0.5.8.  This version of carrierwave is giving deprecation warnings due to the use of ActiveSupport::Memoizable, but the newer version has been fixed.  Unfortunately I wasn't able to update carrierwave due to carrierwave-datamapper's gemspec.  I'm not entirely sure what the rules are with the '~> version' notation, but I have just changed it to '>= version' instead.  This gets rid of the warnings we were getting and all the specs pass.
